### PR TITLE
allow override of hibernate_node size

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ Hibernate-pause Job will
 Hibernate-resume Job will
  - Renable Unscheduled Pod Policy to allow cluster to expand to needed size
 
+Override default hibernate-node size
+ - Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud. 
+
 ## TODO
  - Auto detect Cloud 
+

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ config.load_incluster_config()
 
 castai_api_token = os.environ["API_KEY"]
 cluster_id = os.environ["CLUSTER_ID"]
+instance_type = os.environ["HIBERNATE_NODE"]
 cloud = os.environ["CLOUD"]
 action = os.environ["ACTION"]
 
@@ -67,7 +68,12 @@ if __name__ == '__main__':
 
     if not hibernation_node_id:
         logging.info("No hibernation node found, should make one")
-        hibernation_node_id = create_hibernation_node(cluster_id, castai_api_token, instance_type=instance_type[cloud],
+        hibernate_node_size = ""
+        if instance_type != "":
+            hibernate_node_size = instance_type
+        else:
+            hibernate_node_size = instance_type[cloud]
+        hibernation_node_id = create_hibernation_node(cluster_id, castai_api_token, instance_type=hibernate_node_size,
                                                           k8s_taint=castai_pause_toleration, cloud=cloud)
 
     if hibernation_node_id:

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -145,6 +145,8 @@ spec:
                     fieldPath: spec.nodeName
               - name: CLOUD
                 value: "AKS"
+              - name: HIBERNATE_NODE
+                value: ""
               - name: ACTION
                 value: "pause"
               - name: CLUSTER_ID
@@ -182,6 +184,8 @@ spec:
             env:
               - name: CLOUD
                 value: "AKS"
+              - name: HIBERNATE_NODE
+                value: ""
               - name: ACTION
                 value: "resume"
               - name: CLUSTER_ID


### PR DESCRIPTION
Allow the hibernate_node size to be configured to override the defaults if necessary. Not all regions support all instance types, this will increase regional support. 