### PR TITLE
fix node_type introduced changes with old yaml files

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,7 +24,7 @@ k8s_v1_apps = client.AppsV1Api()
 
 castai_api_token = os.environ["API_KEY"]
 cluster_id = os.environ["CLUSTER_ID"]
-hibernate_node_type = os.environ["HIBERNATE_NODE"]
+hibernate_node_type = os.environ.get("HIBERNATE_NODE")
 cloud = os.environ["CLOUD"]
 action = os.environ["ACTION"]
 
@@ -73,7 +73,7 @@ def handle_suspend():
 
     if not hibernation_node_id:
         logging.info("No hibernation node found, should make one")
-        if hibernate_node_type != "":
+        if hibernate_node_type:
             hibernate_node_size = hibernate_node_type
         else:
             hibernate_node_size = instance_type[cloud]


### PR DESCRIPTION
PR "allow override of hibernate_node size" required to update CronJob YAML files on all customers once releasing latest container. This fix removes braking change (not require updating CronJob manifests everywhere)