### PR TITLE
Check critical pod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,4 @@ CLUSTER_ID="07a38cb2-...."
 HIBERNATE_NODE="Standard_F2s_v2"
 CLOUD="AKS"
 ACTION="pause"
-local_development=True
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: release
 
 APP="castai/hibernate"
 TAG_LATEST=$(APP):latest
-#TAG_LATEST=$(APP):test1
+TAG_VERSION=$(APP):v0.2
 
 gke:
 	(cd ./hack/gke && terraform init && terraform apply -auto-approve)
@@ -21,11 +21,11 @@ pull:
 
 build:
 	@echo "==> Building hibernate container"
-	docker build --cache-from $(TAG_LATEST) --platform linux/amd64 -t $(TAG_LATEST) .
+	docker build --cache-from $(TAG_LATEST) --platform linux/amd64 -t $(TAG_LATEST) -t $(TAG_VERSION) .
 
 publish:
 	@echo "==> pushing to docker hub"
-	docker push $(TAG_LATEST)
+	docker push --all-tags $(APP)
 
 release: pull
 release: build

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ AKS is set by default, but requires changing in both CronJobs "Cloud" env variab
 Hibernate-pause Job will 
  - Disable Unscheduled Pod Policy (to prevent growing cluster)
  - Prepare Hibernation node (node that will stay hosting essential components)
- - Mark essential Deployments with Hibernation toleration
+ - Mark essential Deployments with Hibernation toleration (system critical and with NAMESPACES_TO_KEEP env var)
  - Delete all other nodes (only hibernation node should stay running)
 
 Hibernate-resume Job will
@@ -56,6 +56,20 @@ Hibernate-resume Job will
 Override default hibernate-node size
  - Set the HIBERNATE_NODE environment variable to override the default node sizing selections. Make sure the size selected is appropriate for your cloud. 
 
+Override default NAMESPACES_TO_KEEP
+ - Set the NAMESPACES_TO_KEEP environment variable to override, "opa,istio"" 
+
 ## TODO
  - Auto detect Cloud 
 
+# Development
+
+Create [aks|eks|gke] K8s cluster 
+- create file hack/aks/local.auto.tfvars from example
+- run "make aks"
+- connect to cluster / switch kubectl context
+
+Run code locally
+- copy cluster_id from console.cast.ai to .env file (example .env.example)
+- uncomment in main.py # local_development = True
+- run end2end tests

--- a/app/cast_utils.py
+++ b/app/cast_utils.py
@@ -137,15 +137,28 @@ def delete_all_pausable_nodes(cluster_id: str, castai_api_token: str, hibernatio
             delete_castai_node(cluster_id, castai_api_token, node["id"])
 
 
-def get_castai_nodes(clusterid, castai_apitoken):
+def get_castai_nodes(cluster_id, castai_api_token):
     """ Get all nodes from CAST AI API inside the cluster"""
     url = "https://api.cast.ai/v1/kubernetes/external-clusters/{}/nodes".format
     header_dict = {"accept": "application/json",
-                   "X-API-Key": castai_apitoken}
+                   "X-API-Key": castai_api_token}
 
-    resp = requests.get(url=url(clusterid), headers=header_dict)
+    resp = requests.get(url=url(cluster_id), headers=header_dict)
     if resp.status_code == 200:
         return resp.json()
+
+def get_castai_node_by_id(cluster_id, castai_api_token, node_id):
+    """ Get node by CAST AI id from CAST AI API"""
+    url = "https://api.cast.ai/v1/kubernetes/external-clusters/{}/nodes/{}".format
+    header_dict = {"accept": "application/json",
+                   "X-API-Key": castai_api_token}
+
+    resp = requests.get(url=url(cluster_id, node_id), headers=header_dict)
+    if resp.status_code == 200:
+        if resp.json()['name']:
+            return resp.json()['name']
+        else:
+            return False
 
 
 def delete_castai_node(cluster_id, castai_api_token, node_id):

--- a/app/main.py
+++ b/app/main.py
@@ -34,9 +34,11 @@ logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 castai_pause_toleration = "scheduling.cast.ai/paused-cluster"
 spot_fallback = "scheduling.cast.ai/spot-fallback"
 cast_nodeID_label = "provisioner.cast.ai/node-id"
-cast_namespace = "castai-agent"
-cast_webhook_namespace = "castai-pod-node-lifecycle"
-kube_system_namespace = "kube-system"
+namespaces_to_keep = [
+    "castai-agent",
+    "castai-pod-node-lifecycle",
+    "kube-system"
+]
 
 # TODO: check essential pods CPU/RAM requirements and pick big enough node
 # TODO: not all instances types are available in all regions
@@ -86,9 +88,8 @@ def handle_suspend():
     else:
         raise Exception("no ready hibernation node exist")
 
-    add_special_tolerations(client=k8s_v1_apps, namespace=kube_system_namespace, toleration=castai_pause_toleration)
-    add_special_tolerations(client=k8s_v1_apps, namespace=cast_namespace, toleration=castai_pause_toleration)
-    add_special_tolerations(client=k8s_v1_apps, namespace=cast_webhook_namespace, toleration=castai_pause_toleration)
+    time.sleep(30)
+    [add_special_tolerations(client=k8s_v1_apps, namespace=ns, toleration=castai_pause_toleration) for ns in namespaces_to_keep]
 
     defer_job_node_deletion = False
     my_node_name_id = ""

--- a/app/tests_e2e.py
+++ b/app/tests_e2e.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 import time
 from app import main
@@ -23,6 +22,7 @@ class Scenario:
         logging.info(f"TEST cluster status: {cluster.get('status')}, id: {cluster.get('id')}")
         assert cluster.get('status') == 'ready'
 
+
     @step
     def suspend(self):
         logging.info(f"TEST suspending cluster")
@@ -32,6 +32,7 @@ class Scenario:
                                                                   k8s_label=main.cloud_labels[main.cloud])
         logging.info(f"TEST hibernation node found after cluster suspend: {hibernation_node_id}")
         assert hibernation_node_id
+
 
     @step
     def resume(self):

--- a/app/tests_e2e.py
+++ b/app/tests_e2e.py
@@ -27,11 +27,10 @@ class Scenario:
     def suspend(self):
         logging.info(f"TEST suspending cluster")
         main.handle_suspend()
-        hibernation_node_id = main.hibernation_node_already_exist(client=main.k8s_v1,
-                                                                  taint=main.castai_pause_toleration,
-                                                                  k8s_label=main.cloud_labels[main.cloud])
-        logging.info(f"TEST hibernation node found after cluster suspend: {hibernation_node_id}")
-        assert hibernation_node_id
+
+        nodes = main.get_castai_nodes(main.cluster_id, main.castai_api_token)
+        logging.info(f'Number of nodes found in the cluster: {len(nodes["items"])}')
+        assert len(nodes["items"])==1
 
 
     @step
@@ -39,7 +38,7 @@ class Scenario:
         logging.info(f"TEST resuming cluster")
         main.handle_resume()
         policy_json = main.get_castai_policy(main.cluster_id, main.castai_api_token)
-        assert policy_json["unschedulablePods"]["enabled"]
+        assert policy_json["enabled"]
 
 
 def test_all():
@@ -48,8 +47,8 @@ def test_all():
 
     scenario.cluster_is_ready()
     scenario.suspend()
-    time.sleep(35)
+    time.sleep(15)
     scenario.cluster_is_ready()
-    time.sleep(35)
+    time.sleep(15)
     scenario.resume()
     scenario.cluster_is_ready()

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -147,6 +147,8 @@ spec:
                 value: "AKS"
               - name: HIBERNATE_NODE
                 value: ""
+              - name: NAMESPACES_TO_KEEP
+                value: ""
               - name: ACTION
                 value: "pause"
               - name: CLUSTER_ID
@@ -184,8 +186,6 @@ spec:
             env:
               - name: CLOUD
                 value: "AKS"
-              - name: HIBERNATE_NODE
-                value: ""
               - name: ACTION
                 value: "resume"
               - name: CLUSTER_ID

--- a/hack/aks/example_local.auto.tfvars
+++ b/hack/aks/example_local.auto.tfvars
@@ -1,0 +1,3 @@
+castai_api_token="4523c5...."
+aks_cluster_region="westeurope"
+aks_cluster_name="dev-cluster"

--- a/hack/aks/main.tf
+++ b/hack/aks/main.tf
@@ -29,7 +29,7 @@ module "castai-aks-cluster" {
 
   node_configurations = {
     default = {
-      disk_cpu_ratio = 25
+      disk_cpu_ratio = 5
       subnets        = [azurerm_subnet.internal.id]
       tags           = {
         "env" : "prod"


### PR DESCRIPTION
1. Untaint the Hibernation node at the end, as AKS is removing Tolerations from Kube-system deployments
2. Automatically patch workloads with system-critical class
3. Allow to specify additional namespaces to run on hibernation node.