### PR TITLE
Add support for CronJobTimeZone feature (Kubernetes v1.25+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ kubectl get secret castai-hibernate -n castai-agent -o json | jq --arg API_KEY "
 
 AKS is set by default, but requires changing in both CronJobs "Cloud" env variable to [EKS|GKE|AKS]
 
+### Set Schedule 
+
+Modify the `.spec.schedule` parameter for the Hibernate-pause and Hibernate-resume cronjobs according to  [this syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax). Beginning with Kubernetes v1.25 and later versions, it is possible to define a time zone for a CronJob by assigning a valid time zone name to `.spec.timeZone`. For instance, by assigning `.spec.timeZone: "Etc/UTC"`, Kubernetes will interpret the schedule with respect to Coordinated Universal Time (UTC). To access a list of acceptable time zone options, please refer to the following link: [List of Valid Time Zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+
 ## How it works
 
 Hibernate-pause Job will 

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -122,6 +122,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 22 * * 1-5"
+  timeZone: Asia/Calcutta
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -168,6 +169,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 7 * * 1-5"
+  timeZone: Asia/Calcutta
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -122,7 +122,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 22 * * 1-5"
-  timeZone: Asia/Calcutta
+  timeZone: Etc/UTC
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -172,7 +172,7 @@ metadata:
   namespace: castai-agent
 spec:
   schedule: "0 7 * * 1-5"
-  timeZone: Asia/Calcutta
+  timeZone: Etc/UTC
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
This pull request adds support for setting the timezone in CronJobs by specifying a valid time zon. You can specify a time zone for a CronJob by setting .spec.timeZone to the name of a valid [time zone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). For example, setting `.spec.timeZone: "Etc/UTC"` instructs Kubernetes to interpret the schedule relative to Coordinated Universal Time.